### PR TITLE
いいねランキング機能の不具合の修正

### DIFF
--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -28,10 +28,10 @@ class MicropostsController < ApplicationController
   end
 
   def rank
-    @like_ranks = Micropost.find(Like.group(:micropost_id)
+    @like_ranks = Micropost.unscoped.find(Like.group(:micropost_id)
                            .order('count(micropost_id) desc').limit(5).pluck(:micropost_id))
     @month_data = Like.where(updated_at: Time.current.all_month)
-    @month_ranks = Micropost.find(@month_data.group(:micropost_id)
+    @month_ranks = Micropost.unscoped.find(@month_data.group(:micropost_id)
                             .order('count(micropost_id) desc').limit(5).pluck(:micropost_id))
     @hash = Gmaps4rails.build_markers(@like_ranks) do |micropost, marker|
       marker.lat micropost.latitude


### PR DESCRIPTION
いいねランキング昨日の不具合の修正をしました。

前：いいねランキングの順位が順番がバラバラの状態で出力されていました。原因を確認したところMicropostモデルでdefault-scopeを用いて作成順にorderしていたことであるとわかりました。

後：ランキングの抽出条件に 'unscoped' を追加することで、正常なランキング結果が得られるようになりました。