### PR TITLE
fix:ユーザー一覧ページ下部に余白を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -344,6 +344,7 @@ small {
 .users {
   display: flex;
   flex-wrap: wrap;
+  margin-bottom: 40px;
   .userinfo {
     margin-top: 30px;
     display: inline-block ;


### PR DESCRIPTION
## 概要

ユーザー一覧ページ下部に余白を追加

## この変更の検証方法

chromeの検証ツールで確認